### PR TITLE
feat(default): upgrade to use authbot to allow ruleset

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,10 +28,10 @@ jobs:
       packages: 'write'
       actions: 'read'
     steps:
-      - uses: AtomiCloud/actions.setup-nix@v1
-        # with:
-        #   auth-bot-app-id: ${{ vars.AUTH_BOT_APP_ID }}
-        #   auth-bot-secret-key: ${{ secrets.AUTH_BOT_SECRET_KEY }}
+      - uses: AtomiCloud/actions.setup-nix@v2
+        with:
+          auth-bot-app-id: ${{ vars.AUTH_BOT_APP_ID }}
+          auth-bot-secret-key: ${{ secrets.AUTH_BOT_SECRET_KEY }}
       - uses: AtomiCloud/actions.cache-npm@v1
 
       - name: Release


### PR DESCRIPTION
- updated action from v1 to v2
- enabled auth-bot-app-id and auth-bot-secret-key

this upgrade allows the use of authbot for enhanced security and configuration management in the CI workflow.