### PR TITLE
feat: support namespacelabs cache on macOS via file:// binary cache

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,14 @@
+## [Unreleased]
+
+### ✨ Features ✨
+
+- **macOS Namespace cache**: `namespacelabs: 'true'` now works on macOS runners. Because the
+  APFS root volume is sealed (no `/nix` mount), the action persists a local `file://` binary
+  cache on a Namespace cache volume and pushes realized devShell closures back at end of job
+  via an automatic post hook. This **supersedes** the previous "use non-namespacelabs version
+  for macos" guidance — macOS callers can now use `namespacelabs: 'true'` with the standard
+  cache labels. See the README for runner labels and operational semantics.
+
 ## [3.0.0](https://github.com/AtomiCloud/actions.setup-nix/compare/v2.6.0...v3.0.0) (2026-06-10)
 
 

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Setup AtomiCloud's Nix Action
 
-Setup AtomiCloud CI Nix (Compatible with Namespace)
+Setup AtomiCloud CI Nix (Compatible with Namespace, on Linux **and macOS**).
 
 # Get Started
 
@@ -14,8 +14,70 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # change this
-      - uses: AtomiCloud/actions.setup-nix@v1.0.0
+      - uses: AtomiCloud/actions.setup-nix@v3
 ```
+
+## macOS on Namespace runners
+
+`namespacelabs: 'true'` now works on macOS runners (previously macOS callers had to use
+`namespacelabs: 'false'` and cold-realize their whole dev-shell closure from
+`cache.nixos.org` every run).
+
+macOS's APFS root volume is sealed, so `/nix` cannot be a cache-volume mount the way it is
+on Linux. Instead, on macOS the action persists a **local `file://` binary cache** on a
+Namespace cache volume:
+
+1. The Namespace cache volume is mounted at `darwin-cache-path` (default `/tmp/nix-cache`).
+2. Nix is installed via the Determinate Systems installer with
+   `extra-substituters = file://<darwin-cache-path>?priority=10` (plus the usual remote
+   caches), `require-sigs = false`, and `fallback = true`.
+3. At **end of job** (only on success), a bundled post hook realizes every devShell closure
+   and `nix copy`s it back into the `file://` cache. `nix copy` is incremental, so warm
+   runs cost seconds; the one-time cold push of a multi-GB closure is ~1–3 min.
+
+This write-back is automatic — callers do **not** add a trailing step.
+
+### Required runner labels (caller side)
+
+macOS callers need the same cache-volume label scheme Linux already requires:
+
+```yaml
+jobs:
+  build:
+    runs-on:
+      - nscloud-macos-... # your macOS runner, suffixed -with-cache where applicable
+      - nscloud-cache-size-20gb # minimum cache size label is 20GB
+      - nscloud-cache-tag-atomi-nix-darwin-cache # org convention for darwin
+    steps:
+      - uses: AtomiCloud/actions.setup-nix@v3
+        with:
+          namespacelabs: 'true'
+      - run: nix develop .#default -c true
+```
+
+- `<runner>-with-cache`, `nscloud-cache-size-<N>gb` (min **20**), `nscloud-cache-tag-<name>`.
+- Org convention for darwin: `nscloud-cache-tag-atomi-nix-darwin-cache`.
+
+### Operational semantics
+
+- **Commit on success only**: the cache volume commits its new state only when the job
+  exits 0. A failed job pushes nothing (the post hook is gated on `success()`) and the
+  volume does not commit.
+- **Idle expiry**: idle volumes expire after ~14 days. Tag-only release cadences may go
+  cold — consider a scheduled warm-up job that runs the shell to refresh the volume.
+- **Concurrent matrix jobs** fork the volume and commit last-writer-wins. This is fine when
+  the jobs share a closure.
+- **No GC**: the `file://` cache is never garbage-collected; it resets only on volume expiry.
+- **Safe everywhere**: the post hook is a no-op `notice` (never a failure) on runners
+  without the cache volume (e.g. `namespacelabs: 'false'`), if nix is missing, or if the
+  cache path is absent/unwritable.
+
+### Security trade-off
+
+The macOS path sets `require-sigs = false`, because paths copied into the local `file://`
+cache via `nix copy` are unsigned. This is CI-acceptable and is called out here so it is a
+conscious choice. The Linux Namespace path and all `namespacelabs: 'false'` paths are
+unchanged and still require signatures.
 
 <!-- prettier-ignore-start -->
 <!-- action-docs-inputs -->
@@ -24,6 +86,7 @@ jobs:
 | parameter | description | required | default |
 | --- | --- | --- | --- |
 | namespacelabs | Using Namespace Lab's runners | `false` | true |
+| darwin-cache-path | Mount path for the Namespace cache volume used as a file:// binary cache on macOS | `false` | /tmp/nix-cache |
 | checkout | Whether to checkout the repository | `false` | true |
 | short-length | length for short values | `false` | 7 |
 <!-- action-docs-inputs -->

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   namespacelabs:
     default: 'true'
     description: "Using Namespace Lab's runners"
+  darwin-cache-path:
+    default: '/tmp/nix-cache'
+    description: 'Mount path for the Namespace cache volume used as a file:// binary cache on macOS'
   checkout:
     default: 'true'
     description: 'Whether to checkout the repository'
@@ -75,53 +78,107 @@ runs:
       with:
         fetch-depth: 0
 
-    # NAMESPACE LAB VERSION
+    # COMPUTE NIX CONFIG
+    # One source of truth for substituters / trusted-public-keys, consumed by whichever
+    # single installer runs below. Keeps the existing combinations byte-identical while
+    # adding the macOS Namespace file:// binary cache.
+    - name: Compute Nix Config
+      id: nixconf
+      shell: bash
+      env:
+        NAMESPACELABS: ${{ inputs.namespacelabs }}
+        RUNNER_OS: ${{ runner.os }}
+        ATTIC: ${{ inputs.attic }}
+        ATTIC_URL: ${{ inputs.attic-url }}
+        ATTIC_CACHE: ${{ inputs.attic-cache }}
+        ATTIC_PUBLIC_KEY: ${{ inputs.attic-public-key }}
+        DARWIN_CACHE_PATH: ${{ inputs.darwin-cache-path }}
+      run: |
+        set -euo pipefail
+        base_subs="https://nix-community.cachix.org?priority=41 https://numtide.cachix.org?priority=42 https://cache.nixos.org/"
+        base_keys="cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE="
+
+        subs="$base_subs"
+        keys="$base_keys"
+
+        # macOS Namespace runners cannot mount /nix (sealed APFS root); prepend a local
+        # file:// binary cache served off the Namespace cache volume instead.
+        darwin_ns="false"
+        if [ "$NAMESPACELABS" = "true" ] && [ "$RUNNER_OS" = "macOS" ]; then
+          darwin_ns="true"
+          subs="file://${DARWIN_CACHE_PATH}?priority=10 $subs"
+        fi
+
+        if [ "$ATTIC" = "true" ]; then
+          subs="$subs ${ATTIC_URL}/${ATTIC_CACHE}?priority=43"
+          keys="$keys $ATTIC_PUBLIC_KEY"
+        fi
+
+        {
+          echo "config<<__ATOMI_NIXCONF__"
+          echo "fallback = true"
+          echo "substituters = $subs"
+          echo "trusted-public-keys = $keys"
+          # Paths copied into the file:// cache via `nix copy` are unsigned.
+          if [ "$darwin_ns" = "true" ]; then
+            echo "require-sigs = false"
+          fi
+          echo "__ATOMI_NIXCONF__"
+        } >> "$GITHUB_OUTPUT"
+
+    # NAMESPACE LAB VERSION (Linux): persist the nix store directly on the cache volume.
     - name: Setup Nix Folder
       shell: bash
-      if: inputs.namespacelabs == 'true'
+      if: inputs.namespacelabs == 'true' && runner.os == 'Linux'
       run: |
         sudo mkdir /nix
-        sudo chown $USER /nix
+        sudo chown "$USER" /nix
     - name: Cache Nix
       uses: namespacelabs/nscloud-cache-action@v1
-      if: inputs.namespacelabs == 'true'
+      if: inputs.namespacelabs == 'true' && runner.os == 'Linux'
       with:
         path: /nix
-    - name: Install Nix
-      if: inputs.namespacelabs == 'true' && inputs.attic == 'true'
+
+    # NAMESPACE LAB VERSION (macOS): the APFS root volume is sealed, so /nix cannot be a
+    # mount point. Persist a local file:// binary cache on the Namespace cache volume
+    # instead. Must run AFTER checkout (Namespace requirement).
+    - name: Cache Nix (Darwin file:// binary cache)
+      uses: namespacelabs/nscloud-cache-action@v1
+      if: inputs.namespacelabs == 'true' && runner.os == 'macOS'
+      with:
+        path: ${{ inputs.darwin-cache-path }}
+
+    # INSTALL NIX — exactly one installer runs per (namespacelabs, os), all fed by the
+    # single computed config above.
+    - name: Install Nix (Namespace Linux)
+      if: inputs.namespacelabs == 'true' && runner.os == 'Linux'
       uses: cachix/install-nix-action@v31
       with:
-        extra_nix_config: |
-          fallback = true
-          substituters = https://nix-community.cachix.org?priority=41 https://numtide.cachix.org?priority=42 https://cache.nixos.org/ ${{ inputs.attic-url }}/${{ inputs.attic-cache }}?priority=43
-          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE= ${{ inputs.attic-public-key }}
-    - name: Install Nix
-      if: inputs.namespacelabs == 'true' && inputs.attic == 'false'
-      uses: cachix/install-nix-action@v31
-      with:
-        extra_nix_config: |
-          fallback = true
-          substituters = https://nix-community.cachix.org?priority=41 https://numtide.cachix.org?priority=42 https://cache.nixos.org/
-          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE=
+        extra_nix_config: ${{ steps.nixconf.outputs.config }}
 
-    # NATIVE VERSION
-    - name: Install Nix
+    - name: Install Nix (Determinate Systems)
+      if: inputs.namespacelabs == 'false' || (inputs.namespacelabs == 'true' && runner.os == 'macOS')
       uses: DeterminateSystems/nix-installer-action@main
-      if: inputs.namespacelabs == 'false' && inputs.attic == 'true'
       with:
-        extra-conf: |
-          fallback = true
-          substituters = https://nix-community.cachix.org?priority=41 https://numtide.cachix.org?priority=42 https://cache.nixos.org/ ${{ inputs.attic-url }}/${{ inputs.attic-cache }}?priority=43
-          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE= ${{ inputs.attic-public-key }}
+        extra-conf: ${{ steps.nixconf.outputs.config }}
 
-    - name: Install Nix
-      uses: DeterminateSystems/nix-installer-action@main
-      if: inputs.namespacelabs == 'false' && inputs.attic == 'false'
+    # AUTOMATIC WRITE-BACK (Namespace macOS): register a post hook that pushes the realized
+    # devShell closures back to the file:// cache at end of job (only on success). Composite
+    # actions have no `post:`, and a relative `uses: ./...` resolves against the consumer's
+    # workspace, so symlink the bundled JS sub-action into the workspace and reference it by
+    # that path — works for external consumers with no version drift.
+    - name: Link cache push hook (Namespace macOS)
+      if: inputs.namespacelabs == 'true' && runner.os == 'macOS'
+      shell: bash
+      run: |
+        set -euo pipefail
+        ln -sfn "$GITHUB_ACTION_PATH/post-cache-push" "$GITHUB_WORKSPACE/.atomi-nix-cache-push"
+
+    - name: Register cache push hook (Namespace macOS)
+      if: inputs.namespacelabs == 'true' && runner.os == 'macOS'
+      uses: ./.atomi-nix-cache-push
       with:
-        extra-conf: |
-          fallback = true
-          substituters = https://nix-community.cachix.org?priority=41 https://numtide.cachix.org?priority=42 https://cache.nixos.org/
-          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs= numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE=
+        cache-path: ${{ inputs.darwin-cache-path }}
 
     # SETUP ATTIC
     - name: Install Attic

--- a/post-cache-push/action.yml
+++ b/post-cache-push/action.yml
@@ -1,0 +1,11 @@
+name: 'AtomiCloud Nix Cache Push'
+description: 'Pushes realized devShell closures to a local file:// binary cache on job success (post hook).'
+inputs:
+  cache-path:
+    description: 'Path to the file:// binary cache directory (the Namespace cache volume mount).'
+    required: true
+runs:
+  using: node20
+  main: noop.js
+  post: push.js
+  post-if: success()

--- a/post-cache-push/file-cache-push.sh
+++ b/post-cache-push/file-cache-push.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Discover every devShell for the current system, realize its closure (instant — the job
+# already built them), and copy the store paths into a local file:// binary cache.
+#
+# Discovery mirrors scripts/cache-shell.sh; kept self-contained here so the post hook has
+# no cross-directory dependencies when it runs from a workspace symlink.
+
+cache_path="${1:?Usage: $0 <cache-path>}"
+nix="${NIX_BIN:-nix}"
+
+echo "🔍 Discovering devShells for current system..."
+system="$("$nix" eval --raw --impure --expr 'builtins.currentSystem')"
+shells="$("$nix" eval --raw --impure --expr "builtins.concatStringsSep \" \" (builtins.attrNames (builtins.getFlake (toString ./.)).outputs.devShells.${system})")"
+echo "📦 Found shells: $shells"
+
+targets=""
+for shell in $shells; do
+  targets="$targets .#devShells.$system.$shell"
+done
+
+echo "🔨 Realizing closures:$targets"
+# shellcheck disable=SC2086
+paths="$("$nix" build $targets --print-out-paths --no-link)"
+
+echo "🫸 Pushing store paths to file://${cache_path}"
+# shellcheck disable=SC2086
+"$nix" copy --to "file://${cache_path}?compression=zstd" $paths
+echo "✅ Pushed devShell closures to local binary cache"

--- a/post-cache-push/noop.js
+++ b/post-cache-push/noop.js
@@ -1,0 +1,4 @@
+// Intentionally empty.
+//
+// This action exists only to register a `post` step (push.js) from within a composite
+// action, which cannot declare `post:` itself. The real work happens at end of job.

--- a/post-cache-push/push.js
+++ b/post-cache-push/push.js
@@ -1,0 +1,91 @@
+// Post step for the AtomiCloud setup-nix action (macOS Namespace path).
+//
+// Pushes the devShell closures realized during the job back to the local file:// binary
+// cache that lives on the Namespace cache volume. The volume only commits when the job
+// exits 0, so this step MUST NEVER fail the job: every error path emits a workflow
+// notice/warning and returns normally. Dependency-free on purpose (no node_modules to
+// vendor) — we emit `::notice::`/`::warning::` workflow commands directly, which is what
+// @actions/core would do anyway.
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function notice(msg) {
+  console.log(`::notice::${msg}`);
+}
+
+function warn(msg) {
+  console.log(`::warning::${msg}`);
+}
+
+function getInput(name) {
+  const key = `INPUT_${name.replace(/ /g, '_').toUpperCase()}`;
+  return (process.env[key] || '').trim();
+}
+
+// Resolve a working `nix`: PATH first, then the default profile (the post context's PATH
+// may not include the installer's shims).
+function resolveNix() {
+  const candidates = ['nix', '/nix/var/nix/profiles/default/bin/nix'];
+  for (const candidate of candidates) {
+    const probe = spawnSync(candidate, ['--version'], { stdio: 'ignore' });
+    if (!probe.error && probe.status === 0) return candidate;
+  }
+  return null;
+}
+
+function main() {
+  const cachePath = getInput('cache-path');
+  if (!cachePath) {
+    notice('setup-nix cache push: no cache-path provided; skipping.');
+    return;
+  }
+
+  let stat;
+  try {
+    stat = fs.statSync(cachePath);
+  } catch {
+    notice(`setup-nix cache push: cache path '${cachePath}' does not exist; skipping.`);
+    return;
+  }
+  if (!stat.isDirectory()) {
+    notice(`setup-nix cache push: cache path '${cachePath}' is not a directory; skipping.`);
+    return;
+  }
+  try {
+    fs.accessSync(cachePath, fs.constants.W_OK);
+  } catch {
+    notice(`setup-nix cache push: cache path '${cachePath}' is not writable; skipping.`);
+    return;
+  }
+
+  const nix = resolveNix();
+  if (!nix) {
+    notice('setup-nix cache push: nix not found on PATH or default profile; skipping.');
+    return;
+  }
+
+  // Bundled alongside this file so it resolves whether __dirname is the real action
+  // checkout or the workspace symlink the composite action created.
+  const script = path.join(__dirname, 'file-cache-push.sh');
+  // The flake whose devShells we cache is the consumer repo at GITHUB_WORKSPACE.
+  const cwd = process.env.GITHUB_WORKSPACE || process.cwd();
+
+  const result = spawnSync('bash', [script, cachePath], {
+    stdio: 'inherit',
+    cwd,
+    env: { ...process.env, NIX_BIN: nix },
+  });
+
+  if (result.error) {
+    warn(`setup-nix cache push: failed to run push script: ${result.error.message}`);
+    return;
+  }
+  if (result.status !== 0) {
+    warn(`setup-nix cache push: push script exited with code ${result.status}; cache may be incomplete.`);
+    return;
+  }
+}
+
+main();


### PR DESCRIPTION
## Problem
  The action has two paths today:
  - namespacelabs:'true' (implicitly Linux-only): `sudo mkdir /nix` + chown, then
    `namespacelabs/nscloud-cache-action@v1` with `path: /nix`, then cachix/install-nix-action.
  - namespacelabs:'false': DeterminateSystems/nix-installer-action with a fixed substituter set.

  On Namespace macOS runners the first path is impossible: macOS's APFS root volume is sealed, so
  `sudo mkdir /nix` fails, and nscloud-cache-action mounts on macOS via `sudo ln -sfn` (see
  namespacelabs/space, internal/cache/exec_mount_darwin.go), which also cannot create /nix. So
  macOS callers must use namespacelabs:'false' and cold-realize their whole dev-shell closure from
  cache.nixos.org every run (~20-25 min for a flutter-sized closure). Note this means
  namespacelabs:'true' on macOS currently ALWAYS fails immediately — no existing caller can depend
  on it, so giving that combination a working branch is backward compatible by construction.

  ## Validated solution pattern (already proven inline in alcohol/neon .github/workflows/cd.yaml)
  Namespace cache volumes DO support macOS (since Oct 2024). Don't try to mount the store — persist
  a LOCAL file:// BINARY CACHE on the volume:
  1. Mount the cache volume at a non-root path: nscloud-cache-action with `path: /tmp/nix-cache`
     (must run AFTER checkout — Namespace requirement).
  2. Install nix with the DeterminateSystems installer, adding to its config:
       extra-substituters = file:///tmp/nix-cache?priority=10   (plus the existing remote caches)
       require-sigs = false        # locally `nix copy`-ed paths are unsigned
       fallback = true
  3. At END OF JOB, push new store paths back:
       nix copy --to 'file:///tmp/nix-cache?compression=zstd' <closure>
     nix copy is incremental (skips paths whose narinfo already exists), so warm-run pushes cost
     seconds; the one-time cold push of a multi-GB closure is ~1-3 min (zstd default level is the
     fast one, volume is local NVMe).
  Facts you can rely on: the volume commits only when the job exits 0; idle volumes expire after
  ~14 days; minimum cache size label is 20GB; `nix build .#devShells.<system>.<name>
  --print-out-paths --no-link` works on mkShell and yields the full runtime closure
  (scripts/cache-shell.sh in this repo already relies on that).

  ## Design requirements

  1. action.yml — macOS branch, no caller-visible UX change beyond runner labels:
     - Guard the three existing Namespace /nix steps ("Setup Nix Folder", "Cache Nix", the
       cachix/install-nix-action installs) with `runner.os == 'Linux'` in their `if:`.
     - Add a macOS branch active when `inputs.namespacelabs == 'true' && runner.os == 'macOS'`:
       a. `namespacelabs/nscloud-cache-action@v1` with new input `darwin-cache-path`
          (default `/tmp/nix-cache`). Positioned after the checkout steps (required ordering).
       b. DeterminateSystems/nix-installer-action with the standard substituter set PLUS
          `file://<darwin-cache-path>?priority=10`, `require-sigs = false`, `fallback = true`,
          and the attic substituter + public key when attic:'true'.
     - Refactor instead of multiplying variants: there are already 4 near-identical "Install Nix"
       steps (namespacelabs × attic). Add ONE bash step that computes the `substituters` and
       `trusted-public-keys` lines into step outputs (from attic inputs, runner.os, namespacelabs,
       darwin-cache-path), then keep exactly ONE cachix/install-nix-action step (Linux Namespace
       path) and ONE DS installer step (everything else), both consuming the computed outputs.
     - Backward compatibility is hard requirement: namespacelabs:'true'+Linux and
       namespacelabs:'false' (any OS) must produce byte-identical nix config to today.

  2. Automatic write-back via a post hook — NOT a caller-added trailing step. Composite actions
     have no `post:`, so use the same mechanism actions/cache uses (save-on-post):
     - Create a minimal in-repo JS sub-action, e.g. ./post-cache-push/ with:
         action.yml:  `runs: { using: node20, main: noop.js, post: push.js, post-if: success() }`
         inputs: `cache-path` (the file:// cache dir)
         noop.js: empty main.
         push.js: discovers all devShells for builtins.currentSystem (reuse/factor the discovery
         logic from scripts/cache-shell.sh into a shared script), `nix build`s them
         (--print-out-paths --no-link; instant since the job already realized them), then
         `nix copy --to "file://<cache-path>?compression=zstd" <paths>`. Exit gracefully with a
         core.notice (NOT a failure) if the cache path doesn't exist, isn't writable, or nix is
         missing — it must be safe on any runner. If PATH in the post context lacks nix, fall back
         to /nix/var/nix/profiles/default/bin/nix.
     - The main composite action invokes this sub-action as a normal step in the macOS branch
       (relative-path `uses: ./post-cache-push` works for actions in the same repo — verify; if
       relative uses doesn't resolve for external consumers, reference it as
       AtomiCloud/actions.setup-nix/post-cache-push@<same-ref> or inline the JS action at repo
       root). Result: the runner fires push.js automatically at end of job, after the caller's
       build steps, with zero extra steps in the caller's workflow.

  3. README.md:
     - Document that namespacelabs:'true' now works on macOS and what it does (file:// binary
       cache on a Namespace cache volume, automatic push at job end).
     - Document the caller-side runner labels (same scheme Linux already requires):
       `<runner>-with-cache`, `nscloud-cache-size-<N>gb` (min 20), `nscloud-cache-tag-<name>`.
       Org convention for darwin: `nscloud-cache-tag-atomi-nix-darwin-cache`.
     - Document operational semantics: volume commits only on job success; idle volumes expire
       after ~14 days (tag-only release cadences may go cold — suggest a scheduled warm-up job);
       concurrent matrix jobs fork the volume and commit last-writer-wins (fine when they share a
       closure); the file:// cache is never GC'd (volume expiry resets it).
     - Flag the security trade-off explicitly: the macOS path sets `require-sigs = false`
       (locally-copied paths are unsigned). CI-acceptable; called out so it's a conscious choice.
     - Update Changelog.md — it currently says "use non-namespacelabs version for macos"; that
       guidance is superseded.

  4. Hygiene: actionlint + shellcheck clean; shell scripts start with `#!/usr/bin/env bash` and
     `set -euo pipefail`; conventional commits (lint messages with `sg`); release per the repo's
     existing vN / vN.M.P tagging flow.

  ## Acceptance criteria
  - A macOS workflow with the three cache labels + `uses: AtomiCloud/actions.setup-nix@v2` with
    namespacelabs:'true', then `nix develop .#<shell> -c true`, and NOTHING else:
    run 1 is cold and the post hook logs the push; run 2's logs show the shell closure
    substituting from `file:///tmp/nix-cache` and the post hook completing in seconds.
  - A failed job does not push (post-if) and does not commit the volume.
  - namespacelabs:'true' on Linux and namespacelabs:'false' anywhere: nix config and step
    behavior identical to the current release (compare rendered config in a test run).
  - The post hook on a runner WITHOUT the cache volume (e.g. namespacelabs:'false') is a no-op
    notice, never a failure.
  - Reference consumer to migrate afterwards (separate repo, do NOT change it here):
    alcohol/neon .github/workflows/cd.yaml's ios job currently inlines this whole pattern
    (checkout + nscloud-cache-action + DS installer with file:// substituter + a manual
    "Push nix store to cache volume" step). Once this action is released, that job should
    collapse to setup-nix + labels only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS support for Namespace runners with namespacelabs enabled.
  * Introduced `darwin-cache-path` input to configure macOS binary cache location.
  * Implemented automatic local binary cache mechanism for macOS with post-job write-back.

* **Documentation**
  * Updated setup guide to document macOS and Linux compatibility.
  * Added macOS Namespace cache behavior documentation and operational guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->