### PR TITLE
fix: own darwin cache path so the post-push hook can write

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -148,6 +148,20 @@ runs:
       with:
         path: ${{ inputs.darwin-cache-path }}
 
+    # The cache action mounts the path root-owned on macOS, but the post-push hook's
+    # `nix copy` runs as the runner user and dies with EACCES ("opening file …: Permission
+    # denied"), leaving the cache permanently empty. Own it — the macOS mirror of the
+    # Linux branch's `sudo chown $USER /nix`.
+    - name: Own Darwin cache path
+      shell: bash
+      if: inputs.namespacelabs == 'true' && runner.os == 'macOS'
+      env:
+        DARWIN_CACHE_PATH: ${{ inputs.darwin-cache-path }}
+      run: |
+        set -euo pipefail
+        target="$(readlink -f "$DARWIN_CACHE_PATH" 2>/dev/null || echo "$DARWIN_CACHE_PATH")"
+        sudo chown -R "$USER" "$target"
+
     # INSTALL NIX — exactly one installer runs per (namespacelabs, os), all fed by the
     # single computed config above.
     - name: Install Nix (Namespace Linux)

--- a/post-cache-push/file-cache-push.sh
+++ b/post-cache-push/file-cache-push.sh
@@ -10,6 +10,16 @@ set -euo pipefail
 cache_path="${1:?Usage: $0 <cache-path>}"
 nix="${NIX_BIN:-nix}"
 
+# Preflight: nix copy runs as this (non-root) user; if the mounted cache volume isn't
+# writable (e.g. the chown step was skipped), fail fast with an actionable message
+# instead of erroring mid-copy with an opaque EACCES.
+if ! touch "${cache_path}/.write-probe" 2>/dev/null; then
+  echo "::warning::${cache_path} is not writable by $(id -un); skipping cache push." \
+    "Ensure setup-nix's 'Own Darwin cache path' step ran (sudo chown -R \$USER ${cache_path}/)." >&2
+  exit 1
+fi
+rm -f "${cache_path}/.write-probe"
+
 echo "🔍 Discovering devShells for current system..."
 system="$("$nix" eval --raw --impure --expr 'builtins.currentSystem')"
 shells="$("$nix" eval --raw --impure --expr "builtins.concatStringsSep \" \" (builtins.attrNames (builtins.getFlake (toString ./.)).outputs.devShells.${system})")"


### PR DESCRIPTION
## Problem

The v3 macOS Namespace path mounts `darwin-cache-path` (default `/tmp/nix-cache`) via `nscloud-cache-action`, which creates it **root-owned**. The post-cache-push hook then runs `nix copy` as the `runner` user and dies immediately:

```
copying 539 paths...
error: opening file "/tmp/nix-cache/nar/….nar.zst.tmp…": Permission denied
##[warning]setup-nix cache push: push script exited with code 1; cache may be incomplete.
```

Because the failure is (intentionally) downgraded to a warning, jobs stay green while the file:// binary cache stays **permanently empty** — every run cold-realizes the closure. Observed in alcohol.neon CD runs [27377947934](https://github.com/AtomiCloud/alcohol.neon/actions/runs/27377947934) (push EACCES) and [27379520436](https://github.com/AtomiCloud/alcohol.neon/actions/runs/27379520436) (warm run: 0 paths from the file cache, volume only 213Mi = pub/cocoapods).

## Fix

- **`action.yml`:** after the darwin cache mount, `sudo chown -R $USER` the mounted path (resolving the symlink) — the macOS mirror of the Linux branch's `sudo chown $USER /nix`.
- **`post-cache-push/file-cache-push.sh`:** writability preflight so any future permission regression fails fast with an actionable message instead of an opaque mid-copy EACCES.

## Verification plan

After release, re-dispatch alcohol.neon CD twice: run 1 post hook must log `✅ Pushed devShell closures`, run 2 must substitute from `file:///tmp/nix-cache` and the iOS job should drop from ~29 min to roughly the xcodebuild-only time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS support for cache path permissions management.
  * Added preflight validation to verify cache path writeability before operations.

* **Bug Fixes**
  * Improved error handling with actionable warning messages when cache operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->