### PR TITLE
fix: re-own cache tree at push time, not only at setup

### DIFF
--- a/post-cache-push/file-cache-push.sh
+++ b/post-cache-push/file-cache-push.sh
@@ -10,15 +10,18 @@ set -euo pipefail
 cache_path="${1:?Usage: $0 <cache-path>}"
 nix="${NIX_BIN:-nix}"
 
-# Preflight: nix copy runs as this (non-root) user; if the mounted cache volume isn't
-# writable (e.g. the chown step was skipped), fail fast with an actionable message
-# instead of erroring mid-copy with an opaque EACCES.
-if ! touch "${cache_path}/.write-probe" 2>/dev/null; then
-  echo "::warning::${cache_path} is not writable by $(id -un); skipping cache push." \
-    "Ensure setup-nix's 'Own Darwin cache path' step ran (sudo chown -R \$USER ${cache_path}/)." >&2
+# The nix daemon (root) creates the store layout (nar/, nix-cache-info) inside the cache
+# the first time it opens the file:// substituter during the build — AFTER the setup-time
+# chown — leaving root-owned dirs that EACCES the push (which runs as this non-root user).
+# Re-own the whole tree now, then probe the nar/ dir (where the copy actually writes).
+sudo chown -R "$(id -un)" "${cache_path}/" 2>/dev/null ||
+  echo "::warning::could not chown ${cache_path}; attempting push anyway" >&2
+mkdir -p "${cache_path}/nar"
+if ! touch "${cache_path}/nar/.write-probe" 2>/dev/null; then
+  echo "::warning::${cache_path}/nar is not writable by $(id -un); skipping cache push." >&2
   exit 1
 fi
-rm -f "${cache_path}/.write-probe"
+rm -f "${cache_path}/nar/.write-probe"
 
 echo "🔍 Discovering devShells for current system..."
 system="$("$nix" eval --raw --impure --expr 'builtins.currentSystem')"


### PR DESCRIPTION
## Problem

v3.1.1's setup-time chown was necessary but not sufficient. Verified in alcohol.neon run [27384729517](https://github.com/AtomiCloud/alcohol.neon/actions/runs/27384729517) (on v3.1.1): the chown step ran, the top-level write probe passed, and the push still failed:

```
error: opening file "/tmp/nix-cache/nar/….nar.zst.tmp…": Permission denied
```

Sequence: setup chowns the (empty) cache dir → during the build, the **nix daemon (root)** opens `file:///tmp/nix-cache` as a substituter for the first time and creates the store layout (`nar/`, `nix-cache-info`) **root-owned** → the post hook's `nix copy` (runner user) cannot write inside `nar/`. The identical first NAR hash failing in every run confirms it.

## Fix

In `file-cache-push.sh`, immediately before copying: `sudo chown -R $(id -un)` the whole cache tree, and move the write probe into `nar/` — the directory the copy actually writes to — so the preflight tests what matters. The setup-time chown stays (it covers volume content restored from previous commits).

## Verification plan

Re-dispatch alcohol.neon CD: post hook must log `✅ Pushed devShell closures`; a follow-up run on the same volume pool should substitute from `file:///tmp/nix-cache`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache initialization and permission management for file-based caches. Enhanced validation now properly verifies write access and provides clearer warnings when setup issues are detected, helping users troubleshoot configuration problems more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->