### PR TITLE
feat: lazy-trees, whole-store darwin push, eval cache, reftable

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -80,6 +80,10 @@ jobs:
   fetcher cache, so repeat `nix develop`/`nix eval` invocations skip re-evaluation. Note the
   eval cache is keyed by the flake's content hash — it helps repeat invocations of the
   *same* tree (multiple steps in a job, re-runs of a commit), not new commits.
+- `lazy-trees = true` is set wherever the **Determinate** installer runs (Namespace macOS
+  and all `namespacelabs: 'false'` paths): evaluation no longer copies/hashes the whole
+  source tree into the store. Upstream nix (Namespace Linux, cachix installer) does not
+  support the setting, so it is omitted there.
 
 ### macOS checkout & case-insensitive APFS
 

--- a/README.MD
+++ b/README.MD
@@ -31,9 +31,11 @@ Namespace cache volume:
 2. Nix is installed via the Determinate Systems installer with
    `extra-substituters = file://<darwin-cache-path>?priority=10` (plus the usual remote
    caches), `require-sigs = false`, and `fallback = true`.
-3. At **end of job** (only on success), a bundled post hook realizes every devShell closure
-   and `nix copy`s it back into the `file://` cache. `nix copy` is incremental, so warm
-   runs cost seconds; the one-time cold push of a multi-GB closure is ~1–3 min.
+3. At **end of job** (only on success), a bundled post hook `nix copy --all`s **every valid
+   store path** — devShell closures, build-time deps (fixed-output fetches), and anything
+   built during the job — back into the `file://` cache. `nix copy` is incremental (already
+   -present paths are skipped), so warm runs cost seconds; the one-time cold push of a
+   multi-GB store is a few minutes.
 
 This write-back is automatic — callers do **not** add a trailing step.
 
@@ -71,6 +73,21 @@ jobs:
 - **Safe everywhere**: the post hook is a no-op `notice` (never a failure) on runners
   without the cache volume (e.g. `namespacelabs: 'false'`), if nix is missing, or if the
   cache path is absent/unwritable.
+
+### Other caches persisted
+
+- `~/.cache/nix` (both OSes, Namespace runners): the flake **eval cache** and flake-input
+  fetcher cache, so repeat `nix develop`/`nix eval` invocations skip re-evaluation. Note the
+  eval cache is keyed by the flake's content hash — it helps repeat invocations of the
+  *same* tree (multiple steps in a job, re-runs of a commit), not new commits.
+
+### macOS checkout & case-insensitive APFS
+
+On macOS the action pre-initializes the workspace with `git init --ref-format=reftable`
+(git >= 2.45) before `actions/checkout` runs. With the default `fetch-depth: 0`, all branch
+refs are fetched; on case-insensitive APFS, two branches differing only in case
+(`Alice/feat-1` vs `alice/feat-2`) would otherwise collide as loose-ref files and corrupt
+the checkout. reftable keeps refs in binary tables, immune to filesystem casing.
 
 ### Security trade-off
 

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,24 @@ runs:
       with:
         short-length: ${{ inputs.short-length }}
 
+    # macOS runners checkout onto case-insensitive APFS: with fetch-depth 0, two branches
+    # whose names differ only in case (Adelphi-Liong/feat-1 vs adelphi-liong/feat-2) collide
+    # as loose-ref files and corrupt the checkout. reftable stores refs in binary tables —
+    # no per-ref files, no collisions. Pre-init so actions/checkout reuses the repo instead
+    # of running its own `git init` (needs git >= 2.45; warns and falls back otherwise).
+    - name: Pre-init repository with reftable refs (macOS)
+      if: inputs.checkout == 'true' && runner.os == 'macOS'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -d "$GITHUB_WORKSPACE/.git" ]; then
+          echo "repository already initialized; leaving ref format as-is"
+        elif git init --ref-format=reftable "$GITHUB_WORKSPACE" 2>/dev/null; then
+          echo "initialized $GITHUB_WORKSPACE with reftable refs"
+        else
+          echo "::warning::$(git version) lacks reftable support; loose refs may collide on case-insensitive APFS"
+        fi
+
     - name: Generate Github App Token
       uses: actions/create-github-app-token@v3
       if: inputs.auth-bot-app-id != '' && inputs.auth-bot-secret-key != ''
@@ -137,7 +155,11 @@ runs:
       uses: namespacelabs/nscloud-cache-action@v1
       if: inputs.namespacelabs == 'true' && runner.os == 'Linux'
       with:
-        path: /nix
+        # ~/.cache/nix holds the flake eval cache — persisting it lets repeat
+        # `nix develop`/`nix eval` invocations skip re-evaluation.
+        path: |
+          /nix
+          ~/.cache/nix
 
     # NAMESPACE LAB VERSION (macOS): the APFS root volume is sealed, so /nix cannot be a
     # mount point. Persist a local file:// binary cache on the Namespace cache volume
@@ -146,7 +168,11 @@ runs:
       uses: namespacelabs/nscloud-cache-action@v1
       if: inputs.namespacelabs == 'true' && runner.os == 'macOS'
       with:
-        path: ${{ inputs.darwin-cache-path }}
+        # ~/.cache/nix holds the flake eval cache and the flake-input fetcher cache —
+        # doubly valuable on macOS where /nix itself starts empty every run.
+        path: |
+          ${{ inputs.darwin-cache-path }}
+          ~/.cache/nix
 
     # The cache action mounts the path root-owned on macOS, but the post-push hook's
     # `nix copy` runs as the runner user and dies with EACCES ("opening file …: Permission
@@ -161,6 +187,16 @@ runs:
         set -euo pipefail
         target="$(readlink -f "$DARWIN_CACHE_PATH" 2>/dev/null || echo "$DARWIN_CACHE_PATH")"
         sudo chown -R "$USER" "$target"
+
+    # The cache action can mount ~/.cache/nix root-owned (same failure mode as the darwin
+    # cache path above); nix then silently skips writing the eval cache, wasting the mount.
+    - name: Own Nix eval cache
+      shell: bash
+      if: inputs.namespacelabs == 'true'
+      run: |
+        set -euo pipefail
+        mkdir -p "$HOME/.cache/nix"
+        sudo chown -R "$USER" "$HOME/.cache/nix"
 
     # INSTALL NIX — exactly one installer runs per (namespacelabs, os), all fed by the
     # single computed config above.

--- a/action.yml
+++ b/action.yml
@@ -136,6 +136,15 @@ runs:
           keys="$keys $ATTIC_PUBLIC_KEY"
         fi
 
+        # Lazy trees skip copying/hashing the source tree into the store at eval
+        # time — but only Determinate Nix understands the setting, so gate it to
+        # the paths that run the Determinate installer (upstream nix on Namespace
+        # Linux would just warn, but keep the config exact).
+        lazy_trees="false"
+        if [ "$NAMESPACELABS" != "true" ] || [ "$RUNNER_OS" = "macOS" ]; then
+          lazy_trees="true"
+        fi
+
         {
           echo "config<<__ATOMI_NIXCONF__"
           echo "fallback = true"
@@ -144,6 +153,9 @@ runs:
           # Paths copied into the file:// cache via `nix copy` are unsigned.
           if [ "$darwin_ns" = "true" ]; then
             echo "require-sigs = false"
+          fi
+          if [ "$lazy_trees" = "true" ]; then
+            echo "lazy-trees = true"
           fi
           echo "__ATOMI_NIXCONF__"
         } >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,10 @@ runs:
         if [ -d "$GITHUB_WORKSPACE/.git" ]; then
           echo "repository already initialized; leaving ref format as-is"
         elif git init --ref-format=reftable "$GITHUB_WORKSPACE" 2>/dev/null; then
+          # actions/checkout only reuses an existing repo when remote.origin.url
+          # string-matches the URL it is about to fetch; otherwise it wipes the
+          # directory and re-inits with the default (loose-ref) format.
+          git -C "$GITHUB_WORKSPACE" remote add origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
           echo "initialized $GITHUB_WORKSPACE with reftable refs"
         else
           echo "::warning::$(git version) lacks reftable support; loose refs may collide on case-insensitive APFS"

--- a/post-cache-push/file-cache-push.sh
+++ b/post-cache-push/file-cache-push.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Discover every devShell for the current system, realize its closure (instant — the job
-# already built them), and copy the store paths into a local file:// binary cache.
+# Copy every valid store path into the local file:// binary cache.
 #
-# Discovery mirrors scripts/cache-shell.sh; kept self-contained here so the post hook has
-# no cross-directory dependencies when it runs from a workspace symlink.
+# Whole-store, not just devShell closures: build-time deps (fixed-output fetches like npm
+# tarballs) and packages built during the job are exactly what macOS re-builds from source
+# every run when they're missing from the cache. `nix copy` checks narinfos first and skips
+# paths already present, so after the first push this is incremental — new paths only.
 
 cache_path="${1:?Usage: $0 <cache-path>}"
 nix="${NIX_BIN:-nix}"
@@ -23,21 +24,6 @@ if ! touch "${cache_path}/nar/.write-probe" 2>/dev/null; then
 fi
 rm -f "${cache_path}/nar/.write-probe"
 
-echo "🔍 Discovering devShells for current system..."
-system="$("$nix" eval --raw --impure --expr 'builtins.currentSystem')"
-shells="$("$nix" eval --raw --impure --expr "builtins.concatStringsSep \" \" (builtins.attrNames (builtins.getFlake (toString ./.)).outputs.devShells.${system})")"
-echo "📦 Found shells: $shells"
-
-targets=""
-for shell in $shells; do
-  targets="$targets .#devShells.$system.$shell"
-done
-
-echo "🔨 Realizing closures:$targets"
-# shellcheck disable=SC2086
-paths="$("$nix" build $targets --print-out-paths --no-link)"
-
-echo "🫸 Pushing store paths to file://${cache_path}"
-# shellcheck disable=SC2086
-"$nix" copy --to "file://${cache_path}?compression=zstd" $paths
-echo "✅ Pushed devShell closures to local binary cache"
+echo "🫸 Pushing all valid store paths to file://${cache_path} (incremental)"
+"$nix" copy --all --to "file://${cache_path}?compression=zstd"
+echo "✅ Pushed store to local binary cache"

--- a/post-cache-push/push.js
+++ b/post-cache-push/push.js
@@ -1,7 +1,7 @@
 // Post step for the AtomiCloud setup-nix action (macOS Namespace path).
 //
-// Pushes the devShell closures realized during the job back to the local file:// binary
-// cache that lives on the Namespace cache volume. The volume only commits when the job
+// Pushes every valid store path from the job back to the local file:// binary cache
+// that lives on the Namespace cache volume. The volume only commits when the job
 // exits 0, so this step MUST NEVER fail the job: every error path emits a workflow
 // notice/warning and returns normally. Dependency-free on purpose (no node_modules to
 // vendor) — we emit `::notice::`/`::warning::` workflow commands directly, which is what
@@ -69,7 +69,7 @@ function main() {
   // Bundled alongside this file so it resolves whether __dirname is the real action
   // checkout or the workspace symlink the composite action created.
   const script = path.join(__dirname, 'file-cache-push.sh');
-  // The flake whose devShells we cache is the consumer repo at GITHUB_WORKSPACE.
+  // Run from the consumer repo at GITHUB_WORKSPACE (harmless for --all, kept for clarity).
   const cwd = process.env.GITHUB_WORKSPACE || process.cwd();
 
   const result = spawnSync('bash', [script, cachePath], {


### PR DESCRIPTION
## Problem

macOS Namespace jobs are 25-30 min while the Linux equivalents are ~1 min. Three root causes in this action:

1. **The darwin `file://` cache only receives devShell closures.** Build-time deps (fixed-output fetches like npm tarballs) and packages built during the job are never pushed — so every macOS run rebuilds them from source. This is why the darwin cache volumes sit at <1GB while Linux `/nix` volumes hold 25GB.
2. **The flake eval cache (`~/.cache/nix`) is not persisted**, so every `nix develop` invocation pays full flake re-evaluation (5-10s each).
3. **Case-insensitive APFS + `fetch-depth: 0`**: two branches whose names differ only in case collide as loose-ref files and corrupt the checkout.

## Changes

- `post-cache-push/file-cache-push.sh`: `nix copy --all` — push every valid store path, not just devShell closures. `nix copy` checks narinfos and skips existing paths, so this stays incremental after the first push.
- `action.yml`: add `~/.cache/nix` to the cache-volume paths on both Linux and macOS, with an ownership fix (the cache action can mount it root-owned, making nix silently skip eval-cache writes).
- `action.yml`: on macOS, pre-init the workspace with `git init --ref-format=reftable` before `actions/checkout` (which reuses an existing repo). reftable stores refs in binary tables — immune to filesystem casing. Warns and falls back on git < 2.45.
- README updated for all three.

## Expected impact

- macOS jobs that currently rebuild registry packages (e.g. neon iOS: 25 min in `nix develop .#cd-ios`) drop to ~3-5 min once the cache is warm.
- Repeat `nix develop` calls within a job skip re-evaluation.
- No more catastrophic checkout failures from branch-name casing on macOS.

https://claude.ai/code/session_01KuammDYVDRj9CYWy8eF8aN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS checkouts now pre-initialize the workspace to reduce corrupted repository issues from case-insensitive APFS ref collisions.
  * Nix caching is expanded to persist additional local evaluation/fetch caches for better reuse across runs.
  * Local binary cache uploads now copy every valid Nix store path (full store), improving incremental warm performance.
* **Bug Fixes**
  * Reduced permission-related cache failures on macOS by ensuring the Nix cache directory exists and is owned by the runner.
* **Documentation**
  * Updated cache and checkout behavior notes, including persisted cache details and timing/behavior for full-store pushes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->