### PR TITLE
feat: determinate installer everywhere, lazy-trees on linux

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,12 +4,44 @@ on:
   push:
 
 jobs:
-  test-linux-namespace:
-    name: Test Local Action (Namespace Linux)
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-4x8-with-cache
-      - nscloud-cache-size-50gb
-      - nscloud-cache-tag-actions-setup-nix-nix-store-cache
+  test:
+    name: Test (${{ matrix.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Namespace Linux amd64
+            runner:
+              - nscloud-ubuntu-22.04-amd64-4x8-with-cache
+              - nscloud-cache-size-50gb
+              - nscloud-cache-tag-actions-setup-nix-nix-store-cache
+            namespacelabs: 'true'
+          - name: Namespace Linux arm64
+            runner:
+              - nscloud-ubuntu-22.04-arm64-4x8-with-cache
+              - nscloud-cache-size-50gb
+              - nscloud-cache-tag-actions-setup-nix-arm64-nix-store-cache
+            namespacelabs: 'true'
+          - name: Namespace macOS arm64
+            runner:
+              - nscloud-macos-sequoia-arm64-6x14-with-cache
+              - nscloud-cache-size-50gb
+              - nscloud-cache-tag-atomi-nix-darwin-cache
+            namespacelabs: 'true'
+          - name: GitHub Linux amd64
+            runner:
+              - ubuntu-latest
+            namespacelabs: 'false'
+          - name: GitHub Linux arm64
+            runner:
+              - ubuntu-24.04-arm
+            namespacelabs: 'false'
+          - name: GitHub macOS arm64
+            runner:
+              - macos-latest
+            namespacelabs: 'false'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     steps:
       # uses: ./ needs the repo present before the action runs, so check out here
       # and disable the action's own checkout.
@@ -17,11 +49,13 @@ jobs:
       - uses: ./
         with:
           checkout: 'false'
+          namespacelabs: ${{ matrix.namespacelabs }}
 
       - name: Verify Determinate Nix + lazy-trees
         run: |
           set -euo pipefail
           nix --version
+          nix --version | grep -q "Determinate Nix"
           lazy="$(nix config show lazy-trees)"
           echo "lazy-trees = $lazy"
           [ "$lazy" = "true" ]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,33 @@
+name: Test
+
+on:
+  push:
+
+jobs:
+  test-linux-namespace:
+    name: Test Local Action (Namespace Linux)
+    runs-on:
+      - nscloud-ubuntu-22.04-amd64-4x8-with-cache
+      - nscloud-cache-size-50gb
+      - nscloud-cache-tag-actions-setup-nix-nix-store-cache
+    steps:
+      # uses: ./ needs the repo present before the action runs, so check out here
+      # and disable the action's own checkout.
+      - uses: actions/checkout@v6
+      - uses: ./
+        with:
+          checkout: 'false'
+
+      - name: Verify Determinate Nix + lazy-trees
+        run: |
+          set -euo pipefail
+          nix --version
+          lazy="$(nix config show lazy-trees)"
+          echo "lazy-trees = $lazy"
+          [ "$lazy" = "true" ]
+
+      - name: Time devshell evals (2nd should be eval-cache warm)
+        run: |
+          set -euo pipefail
+          time nix develop .#ci -c true
+          time nix develop .#ci -c true

--- a/README.MD
+++ b/README.MD
@@ -80,10 +80,10 @@ jobs:
   fetcher cache, so repeat `nix develop`/`nix eval` invocations skip re-evaluation. Note the
   eval cache is keyed by the flake's content hash — it helps repeat invocations of the
   *same* tree (multiple steps in a job, re-runs of a commit), not new commits.
-- `lazy-trees = true` is set wherever the **Determinate** installer runs (Namespace macOS
-  and all `namespacelabs: 'false'` paths): evaluation no longer copies/hashes the whole
-  source tree into the store. Upstream nix (Namespace Linux, cachix installer) does not
-  support the setting, so it is omitted there.
+- `lazy-trees = true` on every path: evaluation no longer copies/hashes the whole source
+  tree into the store. The **Determinate** installer now runs everywhere (it is the only
+  installer whose nix supports the setting); on Namespace Linux the stale install receipt
+  persisted on the warm `/nix` volume is dropped before installing over the existing store.
 
 ### macOS checkout & case-insensitive APFS
 

--- a/action.yml
+++ b/action.yml
@@ -136,15 +136,6 @@ runs:
           keys="$keys $ATTIC_PUBLIC_KEY"
         fi
 
-        # Lazy trees skip copying/hashing the source tree into the store at eval
-        # time — but only Determinate Nix understands the setting, so gate it to
-        # the paths that run the Determinate installer (upstream nix on Namespace
-        # Linux would just warn, but keep the config exact).
-        lazy_trees="false"
-        if [ "$NAMESPACELABS" != "true" ] || [ "$RUNNER_OS" = "macOS" ]; then
-          lazy_trees="true"
-        fi
-
         {
           echo "config<<__ATOMI_NIXCONF__"
           echo "fallback = true"
@@ -154,9 +145,10 @@ runs:
           if [ "$darwin_ns" = "true" ]; then
             echo "require-sigs = false"
           fi
-          if [ "$lazy_trees" = "true" ]; then
-            echo "lazy-trees = true"
-          fi
+          # Lazy trees skip copying/hashing the source tree into the store at
+          # eval time. Determinate Nix runs on every path now, so this is safe
+          # unconditionally.
+          echo "lazy-trees = true"
           echo "__ATOMI_NIXCONF__"
         } >> "$GITHUB_OUTPUT"
 
@@ -214,16 +206,25 @@ runs:
         mkdir -p "$HOME/.cache/nix"
         sudo chown -R "$USER" "$HOME/.cache/nix"
 
-    # INSTALL NIX — exactly one installer runs per (namespacelabs, os), all fed by the
-    # single computed config above.
-    - name: Install Nix (Namespace Linux)
+    # INSTALL NIX — the Determinate installer runs on every path (it is the only
+    # installer that supports lazy-trees), fed by the single computed config above.
+    #
+    # On Namespace Linux the warm cache volume persists the previous run's install
+    # receipt at /nix/receipt.json; the installer refuses to run when it exists
+    # ("Nix is already installed") even though this VM is fresh and still needs the
+    # daemon, /etc/nix and profiles set up. Drop the receipt (and the previous
+    # profile symlinks the installer wants to create itself) and install over the
+    # existing store — store paths and the sqlite db are untouched, which is the
+    # whole point of the volume.
+    - name: Prepare warm Nix store for installer (Namespace Linux)
+      shell: bash
       if: inputs.namespacelabs == 'true' && runner.os == 'Linux'
-      uses: cachix/install-nix-action@v31
-      with:
-        extra_nix_config: ${{ steps.nixconf.outputs.config }}
+      run: |
+        set -euo pipefail
+        sudo rm -f /nix/receipt.json
+        sudo rm -rf /nix/var/nix/profiles/default /nix/var/nix/profiles/default-*-link
 
     - name: Install Nix (Determinate Systems)
-      if: inputs.namespacelabs == 'false' || (inputs.namespacelabs == 'true' && runner.os == 'macOS')
       uses: DeterminateSystems/nix-installer-action@main
       with:
         extra-conf: ${{ steps.nixconf.outputs.config }}


### PR DESCRIPTION
## What

Extends lazy-trees (added in #17 for Determinate paths) to **Namespace Linux** by replacing `cachix/install-nix-action` with the Determinate installer on that path — one installer everywhere, `lazy-trees = true` unconditionally.

## The risky part, tested

The Namespace Linux warm `/nix` volume persists the previous run's install receipt and profile symlinks, which make `nix-installer` refuse to run on a fresh VM. A prep step drops `/nix/receipt.json` + default profile symlinks and installs over the existing store (store paths + sqlite db untouched).

Validated by the new dogfood `Test` workflow (`uses: ./` on a real Namespace Linux runner):
- **Run 1** — warm volume populated by the *cachix* installer (the exact state every existing repo is in): install over it succeeded, ~16s
- **Run 2** — warm volume with a *Determinate* receipt (steady state): prep step cleared it, reinstall succeeded
- Both runs: `nix (Determinate Nix 3.21.1) 2.34.7`, `nix config show lazy-trees` = `true`, devshell evals 8.8s cold → **4.1s warm**

## Notes

- macOS and `namespacelabs: 'false'` paths already used the Determinate installer — unchanged
- The `Test` workflow stays as permanent dogfood CI (the existing CI only exercises the *released* `@v2` action, not the local code)

https://claude.ai/code/session_01KuammDYVDRj9CYWy8eF8aN