### PR TITLE
fix: dogfood local action in own CI workflows

### DIFF
--- a/.github/workflows/⚡reusable-cacheshell.yaml
+++ b/.github/workflows/⚡reusable-cacheshell.yaml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       # Setup
-      - uses: AtomiCloud/actions.setup-nix@v2
+      - uses: AtomiCloud/actions.setup-nix@v3
         if: ${{ matrix.platform.enabled }}
         with:
           namespacelabs: ${{ matrix.platform.namespacelabs }}

--- a/.github/workflows/⚡reusable-precommit.yaml
+++ b/.github/workflows/⚡reusable-precommit.yaml
@@ -18,9 +18,13 @@ jobs:
       - nscloud-cache-size-50gb
       - nscloud-cache-tag-${{ inputs.atomi_platform }}-${{ inputs.atomi_service }}-nix-store-cache
     steps:
-      # Setup
-      - uses: AtomiCloud/actions.setup-nix@v2
+      # Setup — dogfood the local action: `uses: ./` needs the repo present first,
+      # and pinning a released tag here is circular (a broken release would wedge
+      # the CI that gates the next release).
+      - uses: actions/checkout@v6
+      - uses: ./
         with:
+          checkout: 'false'
           attic: 'false'
       - uses: AtomiCloud/actions.cache-nuget@v1
 

--- a/.github/workflows/⚡reusable-release.yaml
+++ b/.github/workflows/⚡reusable-release.yaml
@@ -18,8 +18,11 @@ jobs:
       - nscloud-cache-size-50gb
       - nscloud-cache-tag-${{ inputs.atomi_platform }}-${{ inputs.atomi_service }}-nix-store-cache
     steps:
-      # Setup
-      - uses: AtomiCloud/actions.setup-nix@v2
+      # Setup — dogfood the local action. A plain checkout makes `uses: ./`
+      # resolvable; the action then re-checkouts with the auth-bot token (full
+      # history) for semantic-release.
+      - uses: actions/checkout@v6
+      - uses: ./
         with:
           auth-bot-app-id: ${{ vars.AUTH_BOT_APP_ID }}
           auth-bot-secret-key: ${{ secrets.AUTH_BOT_SECRET_KEY }}


### PR DESCRIPTION
## Problem

Post-#18, main CI failed and blocked the release: the repo's own CI pins `setup-nix@v2` (cachix **single-user** installer), but the shared cache volume was just written by a #18 test run using the Determinate **multi-user** installer — `/nix` is now root-owned, and the single-user installer dies with *"directory /nix exists, but is not writable"*.

This is circular: the release that would fix CI is gated on CI.

## Fix

Dogfood `uses: ./` in the repo's own precommit + release workflows (plain checkout first so `./` resolves; the release path still re-checkouts with the auth-bot token inside the action). Bump the dormant cacheshell workflow `@v2` → `@v3`.

## Lesson for the volume-consolidation migration

**Mixed setup-nix generations must not share a cache volume**: v3.3 (determinate, root-owned /nix) poisons the volume for ≤3.2 consumers (cachix, runner-owned). Repos must be on `@v3` (≥3.3.0) *before* moving to shared tags.

https://claude.ai/code/session_01KuammDYVDRj9CYWy8eF8aN