### PR TITLE
fix: reftable via GIT_DEFAULT_REF_FORMAT, not pre-init

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,3 +65,16 @@ jobs:
           set -euo pipefail
           time nix develop .#ci -c true
           time nix develop .#ci -c true
+
+      # The reftable casing fix relies on the runner's git honoring
+      # GIT_DEFAULT_REF_FORMAT (git >= 2.45) — prove it on the actual macOS image.
+      - name: Verify reftable support (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          set -euo pipefail
+          git version
+          d="$(mktemp -d)"
+          GIT_DEFAULT_REF_FORMAT=reftable git init -q "$d/repo"
+          fmt="$(git -C "$d/repo" rev-parse --show-ref-format)"
+          echo "ref-format: $fmt"
+          [ "$fmt" = "reftable" ]

--- a/README.MD
+++ b/README.MD
@@ -87,11 +87,15 @@ jobs:
 
 ### macOS checkout & case-insensitive APFS
 
-On macOS the action pre-initializes the workspace with `git init --ref-format=reftable`
-(git >= 2.45) before `actions/checkout` runs. With the default `fetch-depth: 0`, all branch
-refs are fetched; on case-insensitive APFS, two branches differing only in case
-(`Alice/feat-1` vs `alice/feat-2`) would otherwise collide as loose-ref files and corrupt
-the checkout. reftable keeps refs in binary tables, immune to filesystem casing.
+On macOS the action exports `GIT_DEFAULT_REF_FORMAT=reftable` (git >= 2.45; ignored by
+older gits) before `actions/checkout` runs, so the checkout's own `git init` creates a
+reftable repository. With the default `fetch-depth: 0`, all branch refs are fetched; on
+case-insensitive APFS, two branches differing only in case (`Alice/feat-1` vs
+`alice/feat-2`) would otherwise collide as loose-ref files and corrupt the checkout.
+reftable keeps refs in binary tables, immune to filesystem casing. (A pre-initialized
+empty repo does not work — `actions/checkout` recreates it for lack of a resolvable HEAD.)
+The variable stays exported for the rest of the job, so later `git init` calls in the same
+macOS job also default to reftable — harmless by design.
 
 ### Security trade-off
 

--- a/action.yml
+++ b/action.yml
@@ -53,24 +53,14 @@ runs:
     # macOS runners checkout onto case-insensitive APFS: with fetch-depth 0, two branches
     # whose names differ only in case (Adelphi-Liong/feat-1 vs adelphi-liong/feat-2) collide
     # as loose-ref files and corrupt the checkout. reftable stores refs in binary tables —
-    # no per-ref files, no collisions. Pre-init so actions/checkout reuses the repo instead
-    # of running its own `git init` (needs git >= 2.45; warns and falls back otherwise).
-    - name: Pre-init repository with reftable refs (macOS)
+    # no per-ref files, no collisions. A pre-initialized empty repo does NOT survive
+    # actions/checkout (no resolvable HEAD → "will be recreated"), so instead steer the
+    # checkout's own `git init` via GIT_DEFAULT_REF_FORMAT (git >= 2.45; older gits
+    # ignore the variable and keep loose refs).
+    - name: Default git to reftable refs (macOS)
       if: inputs.checkout == 'true' && runner.os == 'macOS'
       shell: bash
-      run: |
-        set -euo pipefail
-        if [ -d "$GITHUB_WORKSPACE/.git" ]; then
-          echo "repository already initialized; leaving ref format as-is"
-        elif git init --ref-format=reftable "$GITHUB_WORKSPACE" 2>/dev/null; then
-          # actions/checkout only reuses an existing repo when remote.origin.url
-          # string-matches the URL it is about to fetch; otherwise it wipes the
-          # directory and re-inits with the default (loose-ref) format.
-          git -C "$GITHUB_WORKSPACE" remote add origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
-          echo "initialized $GITHUB_WORKSPACE with reftable refs"
-        else
-          echo "::warning::$(git version) lacks reftable support; loose refs may collide on case-insensitive APFS"
-        fi
+      run: echo "GIT_DEFAULT_REF_FORMAT=reftable" >> "$GITHUB_ENV"
 
     - name: Generate Github App Token
       uses: actions/create-github-app-token@v3


### PR DESCRIPTION
## Problem

The reftable casing fix from #17 doesn't survive `actions/checkout`: a pre-initialized **empty** repo has no resolvable HEAD, so checkout logs *"Unable to clean or reset the repository. The repository will be recreated instead"* and re-inits with default loose refs. Observed in nix-registry run 28911182075 (macOS).

## Fix

Export `GIT_DEFAULT_REF_FORMAT=reftable` (git ≥ 2.45; ignored by older gits) before the checkout steps instead — checkout's **own** `git init` then creates the reftable repo. No pre-init, no remote-url matching games, works on both re-runs and fresh workspaces.

Also adds a macOS test-matrix step proving the runner's git honors the variable.

https://claude.ai/code/session_01KuammDYVDRj9CYWy8eF8aN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS setup now automatically uses a safer Git ref format during checkout, helping avoid ref conflicts on case-insensitive filesystems.

* **Bug Fixes**
  * Added a CI check to verify macOS runners honor the expected Git ref format.
  * Updated setup guidance so the Git setting stays active for the rest of the job, including later Git commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->