### PR TITLE
fix: drop reftable (breaks nix/libgit2), single-ref checkout on macOS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,15 +66,15 @@ jobs:
           time nix develop .#ci -c true
           time nix develop .#ci -c true
 
-      # The reftable casing fix relies on the runner's git honoring
-      # GIT_DEFAULT_REF_FORMAT (git >= 2.45) — prove it on the actual macOS image.
-      - name: Verify reftable support (macOS)
+      # Regression guard for the macOS checkout: the workspace must be a loose-ref
+      # repo (nix reads git flakes via libgit2, which cannot open reftable), and nix
+      # must be able to read it as a git flake.
+      - name: Verify workspace is nix-readable git (macOS)
         if: runner.os == 'macOS'
         run: |
           set -euo pipefail
-          git version
-          d="$(mktemp -d)"
-          GIT_DEFAULT_REF_FORMAT=reftable git init -q "$d/repo"
-          fmt="$(git -C "$d/repo" rev-parse --show-ref-format)"
+          fmt="$(git rev-parse --show-ref-format)"
           echo "ref-format: $fmt"
-          [ "$fmt" = "reftable" ]
+          [ "$fmt" = "files" ]
+          nix flake metadata "git+file://$PWD" > /dev/null
+          echo "nix can read the workspace flake"

--- a/README.MD
+++ b/README.MD
@@ -87,15 +87,16 @@ jobs:
 
 ### macOS checkout & case-insensitive APFS
 
-On macOS the action exports `GIT_DEFAULT_REF_FORMAT=reftable` (git >= 2.45; ignored by
-older gits) before `actions/checkout` runs, so the checkout's own `git init` creates a
-reftable repository. With the default `fetch-depth: 0`, all branch refs are fetched; on
-case-insensitive APFS, two branches differing only in case (`Alice/feat-1` vs
-`alice/feat-2`) would otherwise collide as loose-ref files and corrupt the checkout.
-reftable keeps refs in binary tables, immune to filesystem casing. (A pre-initialized
-empty repo does not work — `actions/checkout` recreates it for lack of a resolvable HEAD.)
-The variable stays exported for the rest of the job, so later `git init` calls in the same
-macOS job also default to reftable — harmless by design.
+With `fetch-depth: 0`, ALL branch refs are fetched; on case-insensitive APFS, two branches
+differing only in case (`Alice/feat-1` vs `alice/feat-2`) collide as loose-ref files and
+corrupt the checkout. On macOS the action therefore checks out **shallow, single-ref**
+(`fetch-depth: 1`), then deepens only the current ref to full history and fetches tags —
+foreign branch refs are never written, so they can never collide. Linux keeps the plain
+`fetch-depth: 0` behavior.
+
+> Why not reftable? It would sidestep casing entirely, but nix reads git flakes through
+> libgit2, which cannot open reftable repositories (`unsupported extension name
+> extensions.refstorage`) — a reftable workspace breaks every flake eval on the runner.
 
 ### Security trade-off
 

--- a/action.yml
+++ b/action.yml
@@ -50,18 +50,10 @@ runs:
       with:
         short-length: ${{ inputs.short-length }}
 
-    # macOS runners checkout onto case-insensitive APFS: with fetch-depth 0, two branches
-    # whose names differ only in case (Adelphi-Liong/feat-1 vs adelphi-liong/feat-2) collide
-    # as loose-ref files and corrupt the checkout. reftable stores refs in binary tables —
-    # no per-ref files, no collisions. A pre-initialized empty repo does NOT survive
-    # actions/checkout (no resolvable HEAD → "will be recreated"), so instead steer the
-    # checkout's own `git init` via GIT_DEFAULT_REF_FORMAT (git >= 2.45; older gits
-    # ignore the variable and keep loose refs).
-    - name: Default git to reftable refs (macOS)
-      if: inputs.checkout == 'true' && runner.os == 'macOS'
-      shell: bash
-      run: echo "GIT_DEFAULT_REF_FORMAT=reftable" >> "$GITHUB_ENV"
-
+    # NOTE (macOS casing): reftable refs would dodge the APFS case-collision problem,
+    # but nix reads git flakes through libgit2, which cannot open reftable repos
+    # ("unsupported extension name extensions.refstorage") — so loose refs it is, and
+    # macOS instead avoids fetching foreign branch refs altogether (see below).
     - name: Generate Github App Token
       uses: actions/create-github-app-token@v3
       if: inputs.auth-bot-app-id != '' && inputs.auth-bot-secret-key != ''
@@ -71,10 +63,17 @@ runs:
         private-key: ${{ inputs.auth-bot-secret-key }}
 
     - name: Checkout Repository With Auth Bot
-      if: inputs.checkout == 'true' && inputs.auth-bot-app-id != '' && inputs.auth-bot-secret-key != ''
+      if: inputs.checkout == 'true' && inputs.auth-bot-app-id != '' && inputs.auth-bot-secret-key != '' && runner.os != 'macOS'
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
+        token: ${{ steps.app-token.outputs.token }}
+
+    - name: Checkout Repository With Auth Bot (macOS)
+      if: inputs.checkout == 'true' && inputs.auth-bot-app-id != '' && inputs.auth-bot-secret-key != '' && runner.os == 'macOS'
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
         token: ${{ steps.app-token.outputs.token }}
 
     - name: Checkout Config
@@ -85,10 +84,33 @@ runs:
         git config user.email auth-bot@atomi.cloud
 
     - name: Checkout Repository
-      if: inputs.checkout == 'true' && inputs.auth-bot-app-id == '' && inputs.auth-bot-secret-key == ''
+      if: inputs.checkout == 'true' && inputs.auth-bot-app-id == '' && inputs.auth-bot-secret-key == '' && runner.os != 'macOS'
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
+
+    - name: Checkout Repository (macOS)
+      if: inputs.checkout == 'true' && inputs.auth-bot-app-id == '' && inputs.auth-bot-secret-key == '' && runner.os == 'macOS'
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+
+    # macOS runners checkout onto case-insensitive APFS: fetch-depth 0 fetches EVERY
+    # branch ref, and two branches whose names differ only in case
+    # (Adelphi-Liong/feat-1 vs adelphi-liong/feat-2) collide as loose-ref files and
+    # corrupt the checkout. So on macOS: shallow single-ref checkout above, then deepen
+    # ONLY the current ref (full history) and grab tags — foreign branch refs are never
+    # written, so they can never collide.
+    - name: Deepen current ref (macOS)
+      if: inputs.checkout == 'true' && runner.os == 'macOS'
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+          git fetch --unshallow --tags origin "$(git rev-parse HEAD)"
+        else
+          git fetch --tags origin "$(git rev-parse HEAD)"
+        fi
 
     # COMPUTE NIX CONFIG
     # One source of truth for substituters / trusted-public-keys, consumed by whichever


### PR DESCRIPTION
## Urgent: v3.3.1 breaks macOS flake evals

nix reads git flakes through **libgit2**, which cannot open reftable repositories:

```
error: opening Git repository ...: unsupported extension name extensions.refstorage (libgit2 error code = 6)
```

Observed in nix-registry run 28919365523 — every macOS job that evals the workspace flake fails on v3.3.1. (The dogfood matrix missed it because it runs with `checkout: 'false'`, which skips the env-var step.)

## Fix — solve casing without reftable

macOS now checks out **shallow single-ref** (`fetch-depth: 1`) and then deepens only the current ref (full history + tags). Foreign branch refs are never written to disk → the APFS case-collision (`Adelphi-Liong/feat-1` vs `adelphi-liong/feat-2`) cannot occur. Bonus: much less ref traffic per checkout. Linux keeps `fetch-depth: 0` unchanged.

Test matrix gains a macOS regression guard: workspace must be a loose-ref repo AND `nix flake metadata git+file://$PWD` must succeed.

https://claude.ai/code/session_01KuammDYVDRj9CYWy8eF8aN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS checkout handling to avoid repository corruption on case-insensitive filesystems.
  * Added a regression check ensuring the checked-out workspace remains readable by Nix as a Git-based flake.
  * Removed reliance on a Git configuration that could break compatibility with tooling on macOS.

* **Documentation**
  * Updated the setup notes to describe the new checkout flow and why the previous approach was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->