### PR TITLE
fix: prioritize attic ahead of cache.nixos.org

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -147,7 +147,10 @@ runs:
         fi
 
         if [ "$ATTIC" = "true" ]; then
-          subs="$subs ${ATTIC_URL}/${ATTIC_CACHE}?priority=43"
+          # Priority 35: ahead of cache.nixos.org (40) — attic is a full mirror
+          # served zstd-compressed from the Cloudflare edge, which beats nixos'
+          # xz over origin for both transfer and decompress. Misses fall through.
+          subs="$subs ${ATTIC_URL}/${ATTIC_CACHE}?priority=35"
           keys="$keys $ATTIC_PUBLIC_KEY"
         fi
 


### PR DESCRIPTION
E2E measures showed nix pulling 200+ paths from cache.nixos.org and only 4 from attic — attic's ?priority=43 loses to cache.nixos.org's advertised 40. Now that the cache is a full mirror (zstd, CF-edge-cached at 29MB/s+ measured), it should win: priority 35. Misses fall through to nixos unchanged.

https://claude.ai/code/session_01KuammDYVDRj9CYWy8eF8aN