### PR TITLE
feat: enable attic reads by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,8 @@ inputs:
     default: ''
     description: Private key for auth bot
   attic:
-    default: 'false'
-    description: 'Configure attic as substituters'
+    default: 'true'
+    description: 'Configure attic as a substituter. Reads need no token (the cache is public); pushes additionally require attic-token.'
   attic-user:
     default: 'primordial'
     description: 'Local server alias used by `attic login`'


### PR DESCRIPTION
Flips `attic` default to `'true'`: every `@v3` consumer gets the primordial substituter + trusted key with **zero workflow changes**. Reads need no token (public cache); the attic client install + login still only run when `attic-token` is provided. `fallback = true` means a downed attic degrades to cache.nixos.org instead of failing.

Measured impact (E2E): cold-host restores drop from 27-33 min to ~2 min (nix-registry) / ~11 min (neon, fat shells).

https://claude.ai/code/session_01KuammDYVDRj9CYWy8eF8aN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Attic caching is now enabled by default.
  - Clarified that cache reads are available without a token, while cache pushes require an Attic token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->