### PR TITLE
feat: sparse-image store fast path on macOS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,10 @@ jobs:
             runner:
               - nscloud-macos-sequoia-arm64-6x14-with-cache
               - nscloud-cache-size-50gb
-              - nscloud-cache-tag-atomi-nix-darwin-cache
+              # Dedicated single-writer tag: on the shared darwin volume, commits from
+              # other org jobs race the store image while it rolls out, making the
+              # attach path impossible to exercise deterministically in CI.
+              - nscloud-cache-tag-actions-setup-nix-darwin-test
             namespacelabs: 'true'
           - name: GitHub Linux amd64
             runner:

--- a/README.MD
+++ b/README.MD
@@ -39,6 +39,23 @@ Namespace cache volume:
 
 This write-back is automatic — callers do **not** add a trailing step.
 
+### Store image fast path (macOS)
+
+On top of the `file://` cache, the action maintains an APFS sparse image
+(`<darwin-cache-path>/nix-store.sparseimage`) that **is** a ready-to-use `/nix`:
+
+- **Attach** (job start): if the image exists and passes verification (`sqlite quick_check`
+  on the nix db), it is mounted at `/nix` in ~1s — replacing the multi-GB NAR unpack that
+  otherwise dominates warm macOS jobs. Any failure discards the image and falls back to the
+  plain substitution flow.
+- **Detach** (job end, success only): the daemon is stopped and the image detached cleanly
+  before the volume commits. Namespace commits volumes only on success, so a crashed job's
+  dirty image dies with its fork — corruption cannot propagate.
+- **Bootstrap**: when no image exists, the post hook creates one from the live store
+  (one-time `rsync` at NVMe speed); the next run attaches it.
+- The `file://` binary cache stays authoritative as the fallback that can always rebuild
+  the image from scratch.
+
 ### Required runner labels (caller side)
 
 macOS callers need the same cache-volume label scheme Linux already requires:

--- a/README.MD
+++ b/README.MD
@@ -50,7 +50,9 @@ On top of the `file://` cache, the action maintains an APFS sparse image
   plain substitution flow.
 - **Detach** (job end, success only): the daemon is stopped and the image detached cleanly
   before the volume commits. Namespace commits volumes only on success, so a crashed job's
-  dirty image dies with its fork — corruption cannot propagate.
+  dirty image dies with its fork. The one remaining path to committing a dirty image — a
+  successful job whose detach fails — poisons the image with a `.dirty` marker, and the
+  next run discards and rebuilds it instead of attaching.
 - **Bootstrap**: when no image exists, the post hook creates one from the live store
   (one-time `rsync` at NVMe speed); the next run attaches it.
 - The `file://` binary cache stays authoritative as the fallback that can always rebuild

--- a/action.yml
+++ b/action.yml
@@ -248,14 +248,10 @@ runs:
               sudo /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t / 2>/dev/null || true
           fi
           if [ -d /nix ] && sudo hdiutil attach -mountpoint /nix -nobrowse -owners on "$img" >/dev/null; then
-            if [ -d /nix/store ] && sudo sqlite3 /nix/var/nix/db/db.sqlite 'PRAGMA quick_check;' 2>/dev/null | grep -q '^ok$'; then
+            if [ -d /nix/store ] && [ -x /nix/var/nix/profiles/default/bin/nix-daemon ] &&
+              sudo sqlite3 /nix/var/nix/db/db.sqlite 'PRAGMA quick_check;' 2>/dev/null | grep -q '^ok$'; then
               echo "✅ store image attached at /nix"
               attached=true
-              # Same trick as the Linux warm volume: the previous run's receipt
-              # would make the installer refuse; the installer still needs to set
-              # up the daemon and /etc/nix on this fresh VM.
-              sudo rm -f /nix/receipt.json
-              sudo rm -rf /nix/var/nix/profiles/default /nix/var/nix/profiles/default-*-link
             else
               echo "::warning::store image failed verification; discarding it"
               sudo hdiutil detach /nix -force >/dev/null 2>&1 || true
@@ -291,10 +287,76 @@ runs:
         sudo rm -f /nix/receipt.json
         sudo rm -rf /nix/var/nix/profiles/default /nix/var/nix/profiles/default-*-link
 
+    # When the store image is attached, the installer must NOT run — it creates its
+    # own APFS volume and mounts it over /nix, shadowing the image (observed). The
+    # bootstrap below replaces it, which also removes its ~60s from the warm path.
     - name: Install Nix (Determinate Systems)
+      if: steps.niximg.outputs.attached != 'true'
       uses: DeterminateSystems/nix-installer-action@main
       with:
         extra-conf: ${{ steps.nixconf.outputs.config }}
+
+    - name: Bootstrap Nix from store image (macOS)
+      shell: bash
+      if: steps.niximg.outputs.attached == 'true'
+      env:
+        NIX_CONF: ${{ steps.nixconf.outputs.config }}
+      run: |
+        set -euo pipefail
+        profile=/nix/var/nix/profiles/default
+
+        # nix.conf — same computed config the installer would have received.
+        sudo mkdir -p /etc/nix
+        {
+          echo "build-users-group = nixbld"
+          echo "experimental-features = nix-command flakes"
+          printf '%s\n' "$NIX_CONF"
+        } | sudo tee /etc/nix/nix.conf >/dev/null
+
+        # Build users: the fresh VM has none; the daemon refuses to build without
+        # them. 8 is plenty for CI.
+        if ! dscl . -read /Groups/nixbld >/dev/null 2>&1; then
+          sudo dscl . -create /Groups/nixbld PrimaryGroupID 30000
+          for i in $(seq 1 8); do
+            sudo dscl . -create "/Users/_nixbld$i" UniqueID $((30000 + i))
+            sudo dscl . -create "/Users/_nixbld$i" PrimaryGroupID 30000
+            sudo dscl . -create "/Users/_nixbld$i" UserShell /usr/bin/false
+            sudo dscl . -create "/Users/_nixbld$i" NFSHomeDirectory /var/empty
+            sudo dscl . -append /Groups/nixbld GroupMembership "_nixbld$i"
+          done
+        fi
+
+        # Plain nix-daemon from the image's profile (no determinate-nixd supervisor
+        # on this path — the standard daemon socket is all the client needs).
+        sudo tee /Library/LaunchDaemons/org.nixos.nix-daemon.plist >/dev/null <<PLIST
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>Label</key><string>org.nixos.nix-daemon</string>
+          <key>ProgramArguments</key>
+          <array><string>${profile}/bin/nix-daemon</string></array>
+          <key>KeepAlive</key><true/>
+          <key>EnvironmentVariables</key>
+          <dict>
+            <key>NIX_SSL_CERT_FILE</key><string>/etc/ssl/cert.pem</string>
+            <key>PATH</key><string>${profile}/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+          </dict>
+        </dict>
+        </plist>
+        PLIST
+        sudo launchctl load -w /Library/LaunchDaemons/org.nixos.nix-daemon.plist
+
+        for _ in $(seq 1 30); do
+          [ -S /nix/var/nix/daemon-socket/socket ] && break
+          sleep 1
+        done
+        [ -S /nix/var/nix/daemon-socket/socket ] || { echo "::error::nix-daemon socket never appeared"; exit 1; }
+
+        echo "${profile}/bin" >> "$GITHUB_PATH"
+        echo "NIX_SSL_CERT_FILE=/etc/ssl/cert.pem" >> "$GITHUB_ENV"
+        "$profile/bin/nix" --version
+        echo "✅ nix bootstrapped from store image (no installer)"
 
     # AUTOMATIC WRITE-BACK (Namespace macOS): register a post hook that pushes the realized
     # devShell closures back to the file:// cache at end of job (only on success). Composite

--- a/action.yml
+++ b/action.yml
@@ -224,6 +224,52 @@ runs:
         mkdir -p "$HOME/.cache/nix"
         sudo chown -R "$USER" "$HOME/.cache/nix"
 
+    # STORE IMAGE (Namespace macOS): a persisted APFS sparse image on the cache volume
+    # IS the nix store. Attaching it at /nix (~1s) replaces the multi-GB NAR unpack
+    # that otherwise dominates warm macOS jobs. Every failure path discards the image
+    # and falls back to the plain file:// substitution flow — and Namespace commits
+    # the volume only on job success, so a crashed job's dirty image dies with its
+    # fork instead of propagating.
+    - name: Attach Nix store image (macOS)
+      id: niximg
+      shell: bash
+      if: inputs.namespacelabs == 'true' && runner.os == 'macOS'
+      env:
+        DARWIN_CACHE_PATH: ${{ inputs.darwin-cache-path }}
+      run: |
+        set -euo pipefail
+        img="${DARWIN_CACHE_PATH}/nix-store.sparseimage"
+        attached=false
+        if [ -f "$img" ]; then
+          # /nix must exist on the sealed root before anything can mount there.
+          if [ ! -d /nix ]; then
+            printf 'nix\n' | sudo tee -a /etc/synthetic.conf >/dev/null
+            sudo /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -B / 2>/dev/null ||
+              sudo /System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util -t / 2>/dev/null || true
+          fi
+          if [ -d /nix ] && sudo hdiutil attach -mountpoint /nix -nobrowse -owners on "$img" >/dev/null; then
+            if [ -d /nix/store ] && sudo sqlite3 /nix/var/nix/db/db.sqlite 'PRAGMA quick_check;' 2>/dev/null | grep -q '^ok$'; then
+              echo "✅ store image attached at /nix"
+              attached=true
+              # Same trick as the Linux warm volume: the previous run's receipt
+              # would make the installer refuse; the installer still needs to set
+              # up the daemon and /etc/nix on this fresh VM.
+              sudo rm -f /nix/receipt.json
+              sudo rm -rf /nix/var/nix/profiles/default /nix/var/nix/profiles/default-*-link
+            else
+              echo "::warning::store image failed verification; discarding it"
+              sudo hdiutil detach /nix -force >/dev/null 2>&1 || true
+              rm -f "$img"
+            fi
+          else
+            echo "::warning::store image could not be attached; discarding it"
+            rm -f "$img"
+          fi
+        else
+          echo "no store image yet; post hook will create one"
+        fi
+        echo "attached=$attached" >> "$GITHUB_OUTPUT"
+
     # INSTALL NIX — the Determinate installer runs on every path (it is the only
     # installer that supports lazy-trees), fed by the single computed config above.
     #

--- a/action.yml
+++ b/action.yml
@@ -240,6 +240,12 @@ runs:
         set -euo pipefail
         img="${DARWIN_CACHE_PATH}/nix-store.sparseimage"
         attached=false
+        # A poison marker means the previous run could not detach cleanly — the
+        # committed image may be dirty; rebuild it rather than trust it.
+        if [ -f "${img}.dirty" ]; then
+          echo "::warning::store image is marked dirty (unclean detach); discarding it"
+          rm -f "$img" "${img}.dirty"
+        fi
         if [ -f "$img" ]; then
           # /nix must exist on the sealed root before anything can mount there.
           if [ ! -d /nix ]; then

--- a/action.yml
+++ b/action.yml
@@ -269,6 +269,9 @@ runs:
           echo "no store image yet; post hook will create one"
         fi
         echo "attached=$attached" >> "$GITHUB_OUTPUT"
+        # The post hook must distinguish image-backed /nix from the installer's own
+        # APFS volume (both are mounts) — tell it explicitly.
+        echo "ATOMI_NIX_IMAGE_ATTACHED=$attached" >> "$GITHUB_ENV"
 
     # INSTALL NIX — the Determinate installer runs on every path (it is the only
     # installer that supports lazy-trees), fed by the single computed config above.

--- a/post-cache-push/file-cache-push.sh
+++ b/post-cache-push/file-cache-push.sh
@@ -27,3 +27,46 @@ rm -f "${cache_path}/nar/.write-probe"
 echo "🫸 Pushing all valid store paths to file://${cache_path} (incremental)"
 "$nix" copy --all --to "file://${cache_path}?compression=zstd"
 echo "✅ Pushed store to local binary cache"
+
+# STORE IMAGE MAINTENANCE (macOS only; no-op elsewhere). The image on the cache
+# volume is the fast path for the next job; the file:// cache above remains the
+# fallback that can always rebuild it.
+[ "$(uname)" = "Darwin" ] || exit 0
+img="${cache_path}/nix-store.sparseimage"
+
+stop_daemon() {
+  sudo launchctl bootout system/org.nixos.nix-daemon 2>/dev/null ||
+    sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist 2>/dev/null || true
+}
+
+if mount | grep -q ' on /nix '; then
+  # Image-backed store: stop the daemon (its binaries live inside the image) and
+  # detach cleanly so the committed image is consistent.
+  echo "🪂 Detaching store image"
+  stop_daemon
+  sync
+  sudo hdiutil detach /nix >/dev/null 2>&1 || sudo hdiutil detach /nix -force >/dev/null 2>&1 ||
+    echo "::warning::could not detach /nix; image may not be committed cleanly" >&2
+  echo "✅ Store image detached"
+elif [ ! -f "$img" ] && [ -d /nix/store ]; then
+  # No image yet: build one from the live store so the NEXT run can attach
+  # instead of unpacking. One-time local copy at NVMe speed.
+  echo "🏗️ Creating store image from live /nix"
+  stop_daemon
+  tmp_mnt="$(mktemp -d)"
+  if hdiutil create -type SPARSE -fs 'Case-sensitive APFS' -size 45g -volname NixStore "$img" >/dev/null &&
+    sudo hdiutil attach -mountpoint "$tmp_mnt" -nobrowse -owners on "$img" >/dev/null; then
+    if sudo rsync -a /nix/ "$tmp_mnt/"; then
+      echo "✅ Store image populated ($(du -h "$img" | cut -f1))"
+    else
+      echo "::warning::store image population failed; removing partial image" >&2
+      sudo hdiutil detach "$tmp_mnt" -force >/dev/null 2>&1 || true
+      rm -f "$img"
+      exit 0
+    fi
+    sudo hdiutil detach "$tmp_mnt" >/dev/null 2>&1 || sudo hdiutil detach "$tmp_mnt" -force >/dev/null 2>&1 || true
+  else
+    echo "::warning::could not create/attach store image; skipping" >&2
+    rm -f "$img"
+  fi
+fi

--- a/post-cache-push/file-cache-push.sh
+++ b/post-cache-push/file-cache-push.sh
@@ -43,13 +43,20 @@ stop_daemon() {
 # attach step knows which; it exports ATOMI_NIX_IMAGE_ATTACHED via GITHUB_ENV.
 if [ "${ATOMI_NIX_IMAGE_ATTACHED:-false}" = "true" ]; then
   # Image-backed store: stop the daemon (its binaries live inside the image) and
-  # detach cleanly so the committed image is consistent.
+  # detach cleanly so the committed image is consistent. A failed detach poisons
+  # the image with a marker — the job still succeeds and commits, but the next
+  # run's attach step sees the marker and discards the image instead of trusting
+  # a possibly-dirty filesystem.
   echo "🪂 Detaching store image"
   stop_daemon
   sync
-  sudo hdiutil detach /nix >/dev/null 2>&1 || sudo hdiutil detach /nix -force >/dev/null 2>&1 ||
-    echo "::warning::could not detach /nix; image may not be committed cleanly" >&2
-  echo "✅ Store image detached"
+  if sudo hdiutil detach /nix >/dev/null 2>&1 || sudo hdiutil detach /nix -force >/dev/null 2>&1; then
+    rm -f "${img}.dirty"
+    echo "✅ Store image detached"
+  else
+    touch "${img}.dirty"
+    echo "::warning::could not detach /nix; poisoned the image so the next run rebuilds it" >&2
+  fi
 elif [ ! -f "$img" ] && [ -d /nix/store ]; then
   # No image yet: build one from the live store so the NEXT run can attach
   # instead of unpacking. One-time local copy at NVMe speed.
@@ -58,7 +65,7 @@ elif [ ! -f "$img" ] && [ -d /nix/store ]; then
   tmp_mnt="$(mktemp -d)"
   if hdiutil create -type SPARSE -fs 'Case-sensitive APFS' -size 45g -volname NixStore "$img" >/dev/null &&
     sudo hdiutil attach -mountpoint "$tmp_mnt" -nobrowse -owners on "$img" >/dev/null; then
-    if sudo rsync -a /nix/ "$tmp_mnt/"; then
+    if sudo rsync -aH /nix/ "$tmp_mnt/"; then
       echo "✅ Store image populated ($(du -h "$img" | cut -f1))"
     else
       echo "::warning::store image population failed; removing partial image" >&2

--- a/post-cache-push/file-cache-push.sh
+++ b/post-cache-push/file-cache-push.sh
@@ -39,7 +39,9 @@ stop_daemon() {
     sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist 2>/dev/null || true
 }
 
-if mount | grep -q ' on /nix '; then
+# /nix is a mount either way (the installer's APFS volume or our image) — only the
+# attach step knows which; it exports ATOMI_NIX_IMAGE_ATTACHED via GITHUB_ENV.
+if [ "${ATOMI_NIX_IMAGE_ATTACHED:-false}" = "true" ]; then
   # Image-backed store: stop the daemon (its binaries live inside the image) and
   # detach cleanly so the committed image is consistent.
   echo "🪂 Detaching store image"


### PR DESCRIPTION
## What

Implements the spike-validated sparse-image warm path: an APFS image on the Namespace cache volume holds a ready-to-use `/nix`; attaching it (~1s measured in the spike) replaces the multi-GB NAR unpack that dominates warm macOS jobs (1-3+ min for fat shells like neon's cd-ios).

## Safety model

- **Verify on attach**: `sqlite quick_check` on the nix db; any failure → discard image, fall back to the existing file:// substitution flow (unchanged, still authoritative)
- **Clean detach on success only**: daemon stopped, `hdiutil detach`, then the volume commits. Namespace commits volumes **only on job success**, so a crashed job's dirty image is discarded with its fork — corruption cannot propagate
- **Self-healing bootstrap**: no image → post hook builds one from the live store (rsync, one-time); next run attaches

## Known unknown (why this PR needs its dogfood runs watched)

Whether `nix-installer` tolerates `/nix` already being an attached populated image (same class of question as #18's install-over-warm-volume, which worked). Two consecutive macOS Test runs on this PR exercise: populate (run 1) → attach + install-over-image (run 2).

https://claude.ai/code/session_01KuammDYVDRj9CYWy8eF8aN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a macOS store image fast path to speed up warm-run setup by reusing a persisted Nix store image.
  * Added validation and automatic fallback to the binary cache when the image is unavailable or fails verification.
  * Added automatic image maintenance after successful cache updates.

* **Documentation**
  * Documented the macOS store image lifecycle, fallback behavior, and setup process.

* **Bug Fixes**
  * Improved macOS CI reliability by preventing concurrent store image updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->